### PR TITLE
Release 0.0.3 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.3] - 2023-10-16
+
+- Add support for security response headers. 
+
 ## [0.0.2] - 2023-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Terraform module for managing a S3 hosted web application that is behind Cloud
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.11.0 |
 
 ## Modules
 
@@ -33,6 +33,7 @@ No modules.
 |------|------|
 | [aws_cloudfront_distribution.s3_distribution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution) | resource |
 | [aws_cloudfront_origin_access_identity.origin_access_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_identity) | resource |
+| [aws_cloudfront_response_headers_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_s3_bucket.cloudfront_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.website_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.cloudfront_logging_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
@@ -51,6 +52,7 @@ No modules.
 | <a name="input_allowed_traffic_cloudwatch_metrics_enabled"></a> [allowed\_traffic\_cloudwatch\_metrics\_enabled](#input\_allowed\_traffic\_cloudwatch\_metrics\_enabled) | Whether or not to enable the metrics for the allowed traffic rule. | `bool` | `true` | no |
 | <a name="input_allowed_traffic_sampled_requests_enabled"></a> [allowed\_traffic\_sampled\_requests\_enabled](#input\_allowed\_traffic\_sampled\_requests\_enabled) | Whether or not to enable the sampled requests (3hr) for the allowed traffic rule. | `bool` | `true` | no |
 | <a name="input_apply_waf_cdn"></a> [apply\_waf\_cdn](#input\_apply\_waf\_cdn) | Wether or not to enable the restriction of IP addresses. | `bool` | `false` | no |
+| <a name="input_attach_response_headers_policy"></a> [attach\_response\_headers\_policy](#input\_attach\_response\_headers\_policy) | Whether or not to create a response headers policy. | `bool` | `false` | no |
 | <a name="input_blocked_traffic_cloudwatch_metrics_enabled"></a> [blocked\_traffic\_cloudwatch\_metrics\_enabled](#input\_blocked\_traffic\_cloudwatch\_metrics\_enabled) | Whether or not to enable the metrics for the blocked traffic rule. | `bool` | `true` | no |
 | <a name="input_blocked_traffic_sampled_requests_enabled"></a> [blocked\_traffic\_sampled\_requests\_enabled](#input\_blocked\_traffic\_sampled\_requests\_enabled) | Whether or not to enable the sampled requests (3hr) for the blocked traffic rule. | `bool` | `true` | no |
 | <a name="input_cache_behavior_allowed_methods"></a> [cache\_behavior\_allowed\_methods](#input\_cache\_behavior\_allowed\_methods) | Controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin. | `list(string)` | <pre>[<br>  "GET",<br>  "HEAD",<br>  "OPTIONS"<br>]</pre> | no |
@@ -73,6 +75,7 @@ No modules.
 | <a name="input_origin_shield_region"></a> [origin\_shield\_region](#input\_origin\_shield\_region) | AWS Region for Origin Shield. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as us-east-2. Based on https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html#choose-origin-shield-region | `string` | `"us-east-1"` | no |
 | <a name="input_price_class"></a> [price\_class](#input\_price\_class) | The price class for this distribution. One of PriceClass\_All, PriceClass\_200, PriceClass\_100. | `string` | `"PriceClass_100"` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The project name. | `string` | n/a | yes |
+| <a name="input_security_headers"></a> [security\_headers](#input\_security\_headers) | n/a | <pre>object({<br>    content_type_options      = optional(map(any))<br>    frame_options             = optional(map(any))<br>    referrer_policy           = optional(map(any))<br>    xss_protection            = optional(map(any))<br>    strict_transport_security = optional(map(any))<br>    content_security_policy   = optional(map(any))<br>  })</pre> | `{}` | no |
 | <a name="input_ssl_protocol_version"></a> [ssl\_protocol\_version](#input\_ssl\_protocol\_version) | Minimum version of the SSL protocol that you want CloudFront to use for HTTPS connections. | `string` | `"TLSv1.2_2021"` | no |
 | <a name="input_ssl_support_method"></a> [ssl\_support\_method](#input\_ssl\_support\_method) | How you want CloudFront to serve HTTPS requests. One of vip or sni-only. | `string` | `"sni-only"` | no |
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -29,14 +29,14 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   default_root_object = var.index_document
 
   default_cache_behavior {
-    allowed_methods        = var.cache_behavior_allowed_methods
-    cached_methods         = var.cache_behavior_cached_methods
-    target_origin_id       = local.s3_origin_id
-    viewer_protocol_policy = var.cache_behavior_viewer_protocol_policy
-    min_ttl                = var.cache_behavior_min_ttl
-    default_ttl            = var.cache_behavior_default_ttl
-    max_ttl                = var.cache_behavior_max_ttl
-
+    allowed_methods            = var.cache_behavior_allowed_methods
+    cached_methods             = var.cache_behavior_cached_methods
+    target_origin_id           = local.s3_origin_id
+    viewer_protocol_policy     = var.cache_behavior_viewer_protocol_policy
+    min_ttl                    = var.cache_behavior_min_ttl
+    default_ttl                = var.cache_behavior_default_ttl
+    max_ttl                    = var.cache_behavior_max_ttl
+    response_headers_policy_id = var.attach_response_headers_policy ? aws_cloudfront_response_headers_policy.policy.id : null
     forwarded_values {
       query_string = false
 
@@ -83,3 +83,64 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     Project     = var.project_name
   }
 }
+
+
+resource "aws_cloudfront_response_headers_policy" "policy" {
+  name = "${var.project_name}-header-policy"
+
+  security_headers_config {
+
+    dynamic "content_type_options" {
+      for_each = var.security_headers.content_type_options == null ? [] : [var.security_headers.content_type_options]
+      content {
+        override = lookup(content_type_options.value, "override", null)
+      }
+    }
+
+    dynamic "frame_options" {
+      for_each = var.security_headers.frame_options == null ? [] : [var.security_headers.frame_options]
+      content {
+        frame_option = lookup(frame_options.value, "frame_option", null)
+        override     = lookup(frame_options.value, "override", null)
+      }
+    }
+
+    dynamic "referrer_policy" {
+      for_each = var.security_headers.referrer_policy == null ? [] : [var.security_headers.referrer_policy]
+      content {
+        referrer_policy = lookup(referrer_policy.value, "referrer_policy", null)
+        override        = lookup(referrer_policy.value, "override", null)
+      }
+    }
+
+    dynamic "xss_protection" {
+      for_each = var.security_headers.xss_protection == null ? [] : [var.security_headers.xss_protection]
+      content {
+        mode_block = lookup(xss_protection.value, "mode_block", null)
+        protection = lookup(xss_protection.value, "protection", null)
+        override   = lookup(xss_protection.value, "override", null)
+      }
+    }
+
+    dynamic "strict_transport_security" {
+      for_each = var.security_headers.strict_transport_security == null ? [] : [var.security_headers.strict_transport_security]
+      content {
+        access_control_max_age_sec = lookup(strict_transport_security.value, "access_control_max_age_sec", null)
+        include_subdomains         = lookup(strict_transport_security.value, "include_subdomains", null)
+        preload                    = lookup(strict_transport_security.value, "preload", null)
+        override                   = lookup(strict_transport_security.value, "override", null)
+      }
+    }
+
+    dynamic "content_security_policy" {
+      for_each = var.security_headers.content_security_policy == null ? [] : [var.security_headers.content_security_policy]
+      content {
+        content_security_policy = lookup(content_security_policy.value, "content_security_policy", null)
+        override                = lookup(content_security_policy.value, "override", null)
+      }
+    }
+
+  }
+}
+
+

--- a/docs/example.tf
+++ b/docs/example.tf
@@ -1,7 +1,7 @@
 
 module "s3_site" {
   source  = "madelabs/cloudfront-site/aws"
-  version = "0.0.2"
+  version = "0.0.3"
 
   index_document        = "index.html"
   project_name          = "my-project"
@@ -9,4 +9,38 @@ module "s3_site" {
   acm_certificate_arn   = "arn:aws:acm:us-east-1:1234567890123:certificate/123abcde-f345-6789-0123-9abcdefgh01"
   origin_shield_enabled = false
   origin_shield_region  = "us-east-1"
+  create_waf            = true
+  apply_waf_cdn         = true
+
+  allowed_ips = var.my_list_of_ips
+
+  attach_response_headers_policy = true
+  security_headers = {
+    content_type_options = {
+      override = true
+    }
+    frame_options = {
+      frame_option = "DENY"
+      override     = true
+    }
+    referrer_policy = {
+      referrer_policy = "same-origin"
+      override        = true
+    }
+    xss_protection = {
+      mode_block = true
+      protection = true
+      override   = true
+    }
+    strict_transport_security = {
+      access_control_max_age_sec = "63072000"
+      include_subdomains         = true
+      preload                    = true
+      override                   = true
+    }
+    content_security_policy = {
+      content_security_policy = "frame-ancestors 'none'; default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self'; object-src 'none'"
+      override                = true
+    }
+  }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aws = {
-      version = "~> 5.5.0"
+      version = ">= 5.11.0"
       source  = "hashicorp/aws"
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -212,3 +212,21 @@ variable "custom_error_response" {
   }]
   description = "Custom Error Response Arguments"
 }
+
+variable "security_headers" {
+  type = object({
+    content_type_options      = optional(map(any))
+    frame_options             = optional(map(any))
+    referrer_policy           = optional(map(any))
+    xss_protection            = optional(map(any))
+    strict_transport_security = optional(map(any))
+    content_security_policy   = optional(map(any))
+  })
+  default = {}
+}
+
+variable "attach_response_headers_policy" {
+  type        = bool
+  description = "Whether or not to create a response headers policy."
+  default     = false
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Enable support for security response headers. There are other header options that can be added to the `aws_cloudfront_response_headers_policy` but for right now this release is only focusing on security options. 

There is a known [issue ](https://github.com/hashicorp/terraform-provider-aws/issues/21730 )with the AWS provider that the distribution resource will not appropriately disassociate the policy before deletion of the resource, hence the need for the `var.attach_response_headers_policy` variable. A task has been created to revisit this implementation and see if there is a more elegant solution in the future. 

## Why is this PR being done?

This will allow us to meet some of the requirements around HSTS, XSS and other required parameters for security best practices. 


## Checklist - These are **not** mandatory

- [x] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [x] I have deployed this change in another project successfully.

## Optional: Additional Notes

https://github.com/hashicorp/terraform-provider-aws/issues/21730